### PR TITLE
6.2.x - enable portable mode

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,7 @@ cmake -g Ninja \
       -DCMAKE_INSTALL_LIBDIR=lib \
       -DCMAKE_BUILD_TYPE=Release \
       -DFAIL_ON_WARNINGS=ON \
+      -DPORTABLE=ON \
       -DUSE_RTTI=ON \
       -DWITH_GFLAGS=ON \
       -DWITH_JEMALLOC=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 7f34d1b55501f5273d11cd064bd34aef87c51ff114452968b86457f06cdb8ced
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not linux]
   run_exports:
     # Symbols are removed from a minor release to the next.


### PR DESCRIPTION
Otherwse, the resulting library does not on client machines