### PR TITLE
Add older version(s) of rocksdb

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eu
-
+exit 1
 export EXTRA_CXXFLAGS="${CXXFLAGS} -std=c++17 -mmacosx-version-min=10.14"
 
 # Enabling jemalloc does not work on OSX with the following error message:


### PR DESCRIPTION
As far as I know, rocksdb occasionally has API changes between minor versions.
Since I use rust bindings to rocksdb (i.e. rust-rocksdb) in multiple projects for which I want to build conda packages, and since building rocksdb from scratch in the (bioconda) CI usually times out / exceeds resource usage, I'd like to link against pre-built rocksdb instead. For that to work, however, the versions of rocksdb and rust-rocksdb need to be compatible.

The newest 8.x release of rocksdb available from conda-forge is 8.5.3; whereas rust-rocksdb is currently okay with >=8.9.1.
I'd therefore be happy to somehow get a build of rocksdb 8.9.1 (or 8.10.x).

_This PR should not be merged to main, but rather to a separate, yet-to-be-created branch ("8.x", I guess)._

P.S.: I had to introduce a change to be able to submit a draft PR, which is basically an `exit 1` in the build script to avoid accidentally processing/merging/triggering stuff.

See also https://github.com/bioconda/bioconda-recipes/pull/51210

cc @mbargull 