### PR TITLE
[ci skip] Add 6.29.x branch

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,7 +1,10 @@
+bot:
+  abi_migration_branches:
+    - 6.29.x
 build_platform:
   osx_arm64: osx_64
 conda_build:
-  pkg_format: '2'
+  pkg_format: "2"
 conda_forge_output_validation: true
 github:
   branch_name: main


### PR DESCRIPTION
As described in https://github.com/conda-forge/rocksdb-feedstock/pull/77, roscksdb has API changes b/w minor versions. This is to add a branch for `6.29` to take the effect of automated rebuilding for global pinning package updates.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
