### PR TITLE
Add build variants on jemalloc

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,8 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_rocksdb_build_extNone:
-        CONFIG: linux_64_rocksdb_build_extNone
+      linux_64_rocksdb_build_extdefault:
+        CONFIG: linux_64_rocksdb_build_extdefault
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_64_rocksdb_build_extjemalloc:

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_rocksdb_build_extNone:
+        CONFIG: linux_64_rocksdb_build_extNone
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_rocksdb_build_extjemalloc:
+        CONFIG: linux_64_rocksdb_build_extjemalloc
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_rocksdb_build_extNone.yaml
+++ b/.ci_support/linux_64_rocksdb_build_extNone.yaml
@@ -22,6 +22,8 @@ lz4_c:
 - '1.10'
 rocksdb:
 - '9.1'
+rocksdb_build_ext:
+- None
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/linux_64_rocksdb_build_extdefault.yaml
+++ b/.ci_support/linux_64_rocksdb_build_extdefault.yaml
@@ -23,7 +23,7 @@ lz4_c:
 rocksdb:
 - '9.1'
 rocksdb_build_ext:
-- None
+- default
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/linux_64_rocksdb_build_extjemalloc.yaml
+++ b/.ci_support/linux_64_rocksdb_build_extjemalloc.yaml
@@ -1,13 +1,21 @@
 bzip2:
 - '1'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '13'
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 gflags:
 - '2.2'
 lz4_c:
@@ -15,11 +23,11 @@ lz4_c:
 rocksdb:
 - '9.1'
 rocksdb_build_ext:
-- None
+- jemalloc
 snappy:
 - '1.2'
 target_platform:
-- win-64
+- linux-64
 zlib:
 - '1'
 zstd:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,6 +24,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 rocksdb:
 - '9.1'
+rocksdb_build_ext:
+- None
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ macos_machine:
 rocksdb:
 - '9.1'
 rocksdb_build_ext:
-- None
+- default
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,6 +24,8 @@ macos_machine:
 - arm64-apple-darwin20.0.0
 rocksdb:
 - '9.1'
+rocksdb_build_ext:
+- None
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -25,7 +25,7 @@ macos_machine:
 rocksdb:
 - '9.1'
 rocksdb_build_ext:
-- None
+- default
 snappy:
 - '1.2'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -15,7 +15,7 @@ lz4_c:
 rocksdb:
 - '9.1'
 rocksdb_build_ext:
-- None
+- default
 snappy:
 - '1.2'
 target_platform:

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_rocksdb_build_extNone</td>
+              <td>linux_64_rocksdb_build_extdefault</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9522&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rocksdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_rocksdb_build_extNone" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rocksdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_rocksdb_build_extdefault" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/README.md
+++ b/README.md
@@ -31,10 +31,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_rocksdb_build_extNone</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9522&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rocksdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rocksdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_rocksdb_build_extNone" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_rocksdb_build_extjemalloc</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9522&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/rocksdb-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_rocksdb_build_extjemalloc" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,12 +8,12 @@ else
   export CXXFLAGS="${CXXFLAGS} -std=c++17 -mmacosx-version-min=10.14"
 fi
 
-# Enabling jemalloc does not work on OSX with the following error message:
-# "error: unknown attribute 'je_malloc' ignored"
-if [[ "${target_platform}" == osx-* ]]; then
-  export WITH_JEMALLOC="OFF"
+if [[ ! -z "${rocksdb_build_ext+x}" && "${rocksdb_build_ext}" == "jemalloc" ]]; then
+    echo "Building with jemalloc"
+    export WITH_JEMALLOC="ON"
 else
-  export WITH_JEMALLOC="ON"
+    echo "Building without jemalloc"
+    export WITH_JEMALLOC="OFF"
 fi
 
 ### Create Makefiles

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,7 +4,8 @@ c_stdlib_version:          # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 
 rocksdb_build_ext:
-  - None
+  # Default build: no custom allocator, nor extension.
+  - default
   # Enabling jemalloc does not work on OSX with the following error message:
   # "error: unknown attribute 'je_malloc' ignored"
   # jemmaloc is not available on Windows for now.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,3 +2,11 @@ MACOSX_SDK_VERSION:        # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
 c_stdlib_version:          # [osx and x86_64]
   - "10.14"                # [osx and x86_64]
+
+rocksdb_build_ext:
+  - None
+  # Enabling jemalloc does not work on OSX with the following error message:
+  # "error: unknown attribute 'je_malloc' ignored"
+  # jemmaloc is not available on Windows for now.
+  # See: https://github.com/conda-forge/jemalloc-feedstock/blob/aa35a89f85c0c2a232a246a996da62d96eb0e132/recipe/meta.yaml#L16
+  - "jemalloc"  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,6 @@
 {% set name = "rocksdb" %}
 {% set version = "9.10.0" %}
 
-{% set jemalloc_enabled = rocksdb_build_ext == "jemalloc" %}
-{% set build_ext = "_jemalloc" if jemalloc_enabled else ""  %}
-
 package:
   name: rocksdb
   version: {{ version }}
@@ -15,7 +12,7 @@ source:
 
 build:
   number: 1
-  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ build_ext }}
+  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ rocksdb_build_ext }}
   run_exports:
     # Symbols are removed from a minor release to the next.
     # https://abi-laboratory.pro/index.php?view=timeline&l=rocksdb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,9 @@
 {% set name = "rocksdb" %}
 {% set version = "9.10.0" %}
 
+{% set jemalloc_enabled = rocksdb_build_ext == "jemalloc" %}
+{% set build_ext = "_jemalloc" if jemalloc_enabled else ""  %}
+
 package:
   name: rocksdb
   version: {{ version }}
@@ -11,7 +14,8 @@ source:
   sha256: fdccab16133c9d927a183c2648bcea8d956fb41eb1df2aacaa73eb0b95e43724
 
 build:
-  number: 0
+  number: 1
+  string: h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}{{ build_ext }}
   run_exports:
     # Symbols are removed from a minor release to the next.
     # https://abi-laboratory.pro/index.php?view=timeline&l=rocksdb
@@ -25,7 +29,7 @@ requirements:
     - ninja >=1.10,<2
   host:
     - gflags
-    - jemalloc  # [not win]
+    - jemalloc  # [rocksdb_build_ext == "jemalloc"]
     - lz4-c
     - snappy
     - zstd


### PR DESCRIPTION

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fix #97.

I mostly have followed the approach of some other feedstocks, like `folly-feedstock` (see https://github.com/conda-forge/folly-feedstock/pull/1 for its original build variants definition) but without using `ignore_run_exports` and without conditionally adding `jemalloc` to the `run` section ([`jemalloc-feedstock`'s definition of runtime requirements for `jemalloc`](https://github.com/conda-forge/jemalloc-feedstock/blob/aa35a89f85c0c2a232a246a996da62d96eb0e132/recipe/meta.yaml#L22-L25) takes care of that).

@h-vetinari: could you let me know if this is the correct approach to adopt? :pray: 